### PR TITLE
Use the latest version of Trufflehog, and use the checkout provided by the GitHub Action checkout step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL "com.github.actions.description"="Scan repository for secrets with basic t
 LABEL "com.github.actions.icon"="shield"
 LABEL "com.github.actions.color"="yellow"
 
-RUN pip install gitdb2==3.0.0 truffleHog==2.0.99
+RUN pip install gitdb2==3.0.0 truffleHog
 RUN apk --update add git less openssh && \
   rm -rf /var/lib/apt/lists/* && \
   rm /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -55,20 +55,6 @@ steps:
 
 *if custom options argument string is used, it will overwrite default settings
 
-### Private GitHub Repository
-
-Pass a GitHub access token to action to clone from a private GitHub repository.
-You can't use the default `GITHUB_TOKEN` as it doesn't have the permission to clone the repository.
-
-```yaml
-steps:
-- uses: actions/checkout@master
-- name: trufflehog-actions-scan
-  uses: nasa-gibs/trufflehog-actions-scan@master
-  with:
-    githubToken: ${{ secrets.GITHUB_CLONE_TOKEN }} # You have to create an access token manually
-
-```
 
 ----
 

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,6 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
 inputs:
-  githubToken:
-    description: 'GitHub Token to access a private repository.'
-    required: false
   scanArguments:
     description: 'Argument options for scan.'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,4 @@ if [ -n "${INPUT_SCANARGUMENTS}" ]; then
   args="${INPUT_SCANARGUMENTS}" # Overwrite if new options string is provided
 fi
 
-githubRepo="https://github.com/$GITHUB_REPOSITORY" # Overwrite for private repository if token provided
-
 trufflehog file:///github/workspace $args 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,6 @@ if [ -n "${INPUT_SCANARGUMENTS}" ]; then
   args="${INPUT_SCANARGUMENTS}" # Overwrite if new options string is provided
 fi
 
-githubRepo="https://$GITHUB_ACTOR@github.com/$GITHUB_REPOSITORY" # Overwrite for private repository if token provided
+githubRepo="https://github.com/$GITHUB_REPOSITORY" # Overwrite for private repository if token provided
 
 trufflehog file:///github/workspace $args 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,10 +7,6 @@ if [ -n "${INPUT_SCANARGUMENTS}" ]; then
   args="${INPUT_SCANARGUMENTS}" # Overwrite if new options string is provided
 fi
 
-if [ -n "${INPUT_GITHUBTOKEN}" ]; then
-  githubRepo="https://$INPUT_GITHUBTOKEN@github.com/$GITHUB_REPOSITORY" # Overwrite for private repository if token provided
-else
-  githubRepo="https://github.com/$GITHUB_REPOSITORY" # Default target repository
-fi
+githubRepo="https://$GITHUB_ACTOR@github.com/$GITHUB_REPOSITORY" # Overwrite for private repository if token provided
 
-trufflehog $args $githubRepo
+trufflehog file:///github/workspace $args 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,6 @@ if [ -n "${INPUT_SCANARGUMENTS}" ]; then
   args="${INPUT_SCANARGUMENTS}" # Overwrite if new options string is provided
 fi
 
+git config --global --add safe.directory /github/workspace/.git
+
 trufflehog file:///github/workspace $args 


### PR DESCRIPTION
If you set up your Trufflehog action to use a checkout step, you can use the checkout exposed to the repo as a volume rather than having to check out the code repository in the container.

Example config:

```yaml
jobs:
  trufflehog:
    runs-on: ubuntu-latest
    name: Trufflehog
    steps:
      - uses: actions/checkout@v2

      - name: Extract branch name
        shell: bash
        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
        id: extract_branch

      - name: trufflehog-actions-scan
        uses: dopplerhq/trufflehog-actions-scan@master
        with:
          scanArguments: "--regex --max_depth=50 --branch=${{ steps.extract_branch.outputs.branch }} --entropy=False --allow=/github/workspace/.trufflehog/allow --exclude_paths=/github/workspace/.trufflehog/exclude_patterns"
```

Additionally I updated this to use the latest version of trufflehog which supports additional features like the `--allow` flag.